### PR TITLE
Add Smaragdsanktum SQL scripts and import docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# Bloody Raid Module
+
+This module adds the Smaragdsanktum raid with custom NPCs, instance data, waypoints, spell tweaks and loot tables.
+
+## Importing the SQL files
+
+Import the SQL files under `data/sql/db-world` into your AzerothCore world database in the order below:
+
+1. `npc_alice.sql` – registers the starter NPC and boss creature templates.
+2. `instance_smaragdsanktum.sql` – registers the map, instance template and encounter data.
+3. `waypoints.sql` – defines movement paths for the encounter.
+4. `spells_override.sql` – applies custom spell radius, damage and duration tweaks.
+5. `loot_tables.sql` – adds boss loot entries.
+
+Example commands:
+
+```
+mysql -u <user> -p world < data/sql/db-world/npc_alice.sql
+mysql -u <user> -p world < data/sql/db-world/instance_smaragdsanktum.sql
+mysql -u <user> -p world < data/sql/db-world/waypoints.sql
+mysql -u <user> -p world < data/sql/db-world/spells_override.sql
+mysql -u <user> -p world < data/sql/db-world/loot_tables.sql
+```
+
+Replace `world` with the name of your world database.

--- a/data/sql/db-world/instance_smaragdsanktum.sql
+++ b/data/sql/db-world/instance_smaragdsanktum.sql
@@ -1,0 +1,17 @@
+-- Map and instance template for Smaragdsanktum
+SET @MAPID := 930;
+SET @BOSS := 90001;
+
+-- Map registration
+DELETE FROM `map` WHERE `entry`=@MAPID;
+INSERT INTO `map` (`entry`,`name`,`directory`,`map_type`,`expansion`) VALUES (@MAPID,'Smaragdsanktum','Smaragdsanktum',1,2);
+
+-- Instance template
+DELETE FROM `instance_template` WHERE `map`=@MAPID;
+INSERT INTO `instance_template` (`map`,`parent`,`script`,`allowMount`,`insideResurrection`) VALUES
+(@MAPID,0,'instance_smaragdsanktum',0,1);
+
+-- Encounter data
+DELETE FROM `instance_encounters` WHERE `entry`=@BOSS;
+INSERT INTO `instance_encounters` (`entry`,`map`,`difficulty`,`name`,`data`) VALUES
+(@BOSS,@MAPID,0,'The Emerald Matron',@BOSS);

--- a/data/sql/db-world/loot_tables.sql
+++ b/data/sql/db-world/loot_tables.sql
@@ -1,0 +1,7 @@
+-- Loot tables for Smaragdsanktum boss
+SET @BOSS := 90001;
+
+DELETE FROM `creature_loot_template` WHERE `entry`=@BOSS;
+INSERT INTO `creature_loot_template` (`entry`,`item`,`ChanceOrQuestChance`,`lootmode`,`groupid`,`mincountOrRef`,`maxcount`) VALUES
+(@BOSS,50734,15,1,0,1,1), -- Royal Scepter of Terenas II
+(@BOSS,49908,100,1,0,1,3); -- Primordial Saronite

--- a/data/sql/db-world/npc_alice.sql
+++ b/data/sql/db-world/npc_alice.sql
@@ -1,0 +1,15 @@
+-- NPC and Boss templates for Smaragdsanktum
+SET @START_NPC := 90000;
+SET @BOSS := 90001;
+
+-- Creature templates
+DELETE FROM `creature_template` WHERE `entry` IN (@START_NPC, @BOSS);
+INSERT INTO `creature_template` (`entry`,`name`,`subname`,`minlevel`,`maxlevel`,`modelid1`,`faction`,`npcflag`,`scale`,`rank`,`type`,`type_flags`,`InhabitType`,`unit_class`) VALUES
+(@START_NPC,'Alice','Guide to the Smaragdsanktum',80,80,31000,35,1,1,0,7,0,3,1),
+(@BOSS,'The Emerald Matron','',83,83,31001,14,0,1,3,7,0,3,1);
+
+-- Creature models
+DELETE FROM `creature_model_info` WHERE `modelid` IN (31000,31001);
+INSERT INTO `creature_model_info` (`modelid`,`bounding_radius`,`combat_reach`,`gender`) VALUES
+(31000,0.3519,1.5,1),
+(31001,1.5,4.0,2);

--- a/data/sql/db-world/spells_override.sql
+++ b/data/sql/db-world/spells_override.sql
@@ -1,0 +1,5 @@
+-- Spell overrides for Smaragdsanktum
+-- Adjust radius, damage and duration of custom spells
+UPDATE `spell_template` SET `EffectRadiusIndex1`=15 WHERE `entry`=90000;
+UPDATE `spell_template` SET `EffectBasePoints1`=600 WHERE `entry`=90001;
+UPDATE `spell_template` SET `DurationIndex`=28 WHERE `entry`=90002;

--- a/data/sql/db-world/waypoints.sql
+++ b/data/sql/db-world/waypoints.sql
@@ -1,0 +1,7 @@
+-- Waypoints for Smaragdsanktum creatures
+SET @BOSS_PATH := 900001;
+
+DELETE FROM `waypoint_data` WHERE `id`=@BOSS_PATH;
+INSERT INTO `waypoint_data` (`id`,`point`,`position_x`,`position_y`,`position_z`,`delay`,`move_flag`,`action`,`action_chance`,`wpguid`) VALUES
+(@BOSS_PATH,1,0,0,0,0,0,0,100,0),
+(@BOSS_PATH,2,10,0,0,0,0,0,100,0);


### PR DESCRIPTION
## Summary
- add NPC and boss templates for Smaragdsanktum
- register map, instance, waypoints, spells and loot via SQL
- document SQL import steps

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_689cc91192388327a18b96cc97be926a