### PR TITLE
Clean up Alice scripts and remove stray strings

### DIFF
--- a/data/sql/db-world/npc_alice.sql
+++ b/data/sql/db-world/npc_alice.sql
@@ -1,6 +1,4 @@
-codex/add-sql-files-for-game-world-features
-
-codex/add-npc_alice_start.cpp-with-creaturescript
+-- SQL data for NPC Alice
 SET @NPC := 91000;
 SET @GOSSIP_MENU := 91000;
 SET @GOSSIP_TEXT := 91000;
@@ -13,7 +11,6 @@ INSERT INTO `npc_text` (`ID`, `text0_0`) VALUES (@GOSSIP_TEXT, 'Seid ihr bereit 
 
 UPDATE `creature_template` SET `gossip_menu_id`=@GOSSIP_MENU, `npcflag`=`npcflag`|1, `ScriptName`='npc_alice_start' WHERE `entry`=@NPC;
 
-master
 -- NPC and Boss templates for Smaragdsanktum
 SET @START_NPC := 90000;
 SET @BOSS := 90001;
@@ -29,7 +26,3 @@ DELETE FROM `creature_model_info` WHERE `modelid` IN (31000,31001);
 INSERT INTO `creature_model_info` (`modelid`,`bounding_radius`,`combat_reach`,`gender`) VALUES
 (31000,0.3519,1.5,1),
 (31001,1.5,4.0,2);
-codex/add-sql-files-for-game-world-features
-
-master
-master

--- a/src/MP_loader.cpp
+++ b/src/MP_loader.cpp
@@ -4,32 +4,22 @@
  * https://github.com/azerothcore/azerothcore-wotlk/blob/master/LICENSE-AGPL3
  */
 
-codex/modify-cmakelists.txt-for-new-scripts
 // Forward declare AddSC functions from script files
-
-// From SC
-master
 void AddSC_boss_alice();
 void AddSC_instance_smaragdsanktum();
 void AddSC_npc_alice_start();
 
-codex/modify-cmakelists.txt-for-new-scripts
 // Add all scripts
-void Addbloody_raid_modulScripts()
+void AddAliceScripts()
 {
     AddSC_boss_alice();
     AddSC_instance_smaragdsanktum();
     AddSC_npc_alice_start();
-
-void AddAliceScripts() {
-  AddSC_boss_alice();
-  AddSC_instance_smaragdsanktum();
-  AddSC_npc_alice_start();
-master
 }
 
-// Add all
-// cf. the naming convention
-// https://github.com/azerothcore/azerothcore-wotlk/blob/master/doc/changelog/master.md#how-to-upgrade
-// additionally replace all '-' in the module folder name with '_' here
-void Addmod_bloody_raid_modulScripts() { AddAliceScripts(); }
+// Called by the core to add the module's scripts
+void Addmod_bloody_raid_modulScripts()
+{
+    AddAliceScripts();
+}
+

--- a/src/boss_alice.cpp
+++ b/src/boss_alice.cpp
@@ -1,12 +1,6 @@
-codex/modify-cmakelists.txt-for-new-scripts
 /*
  * Placeholder script for boss Alice encounter
  */
-
-#include "ScriptMgr.h"
-
-void AddSC_boss_alice()
-{
 
 #include "ScriptMgr.h"
 #include "ScriptedCreature.h"
@@ -62,9 +56,9 @@ struct boss_alice : public BossAI
         _EnterCombat();
         events.SetPhase(PHASE_ONE);
         events.ScheduleEvent(EVENT_METEOR_STRIKE, 5000, 0, PHASE_ONE);
-        events.ScheduleEvent(EVENT_ICY_GRIP, 15000, 0, PHASE_ONE);
-        events.ScheduleEvent(EVENT_AOE_DAMAGE, 10000, 0, PHASE_ONE);
-        events.ScheduleEvent(EVENT_SLIME_ROOT, 20000, 0, PHASE_ONE);
+        events.ScheduleEvent(EVENT_ICY_GRIP,      15000, 0, PHASE_ONE);
+        events.ScheduleEvent(EVENT_AOE_DAMAGE,    10000, 0, PHASE_ONE);
+        events.ScheduleEvent(EVENT_SLIME_ROOT,    20000, 0, PHASE_ONE);
     }
 
     void JustDied(Unit* /*killer*/) override
@@ -121,15 +115,15 @@ struct boss_alice : public BossAI
                 case EVENT_PHASE_TWO:
                     events.SetPhase(PHASE_TWO);
                     events.ScheduleEvent(EVENT_AOE_DAMAGE, 10000, 0, PHASE_TWO);
-                    events.ScheduleEvent(EVENT_GAS_BOMB, 15000, 0, PHASE_TWO);
+                    events.ScheduleEvent(EVENT_GAS_BOMB,  15000, 0, PHASE_TWO);
                     events.ScheduleEvent(EVENT_SUMMON_SLIME, 20000, 0, PHASE_TWO);
                     break;
                 case EVENT_PHASE_THREE:
                     events.SetPhase(PHASE_THREE);
-                    events.ScheduleEvent(EVENT_BERSERK, 1000, 0, PHASE_THREE);
+                    events.ScheduleEvent(EVENT_BERSERK,     1000, 0, PHASE_THREE);
                     events.ScheduleEvent(EVENT_METEOR_STRIKE, 5000, 0, PHASE_THREE);
-                    events.ScheduleEvent(EVENT_ICY_GRIP, 15000, 0, PHASE_THREE);
-                    events.ScheduleEvent(EVENT_GAS_BOMB, 20000, 0, PHASE_THREE);
+                    events.ScheduleEvent(EVENT_ICY_GRIP,    15000, 0, PHASE_THREE);
+                    events.ScheduleEvent(EVENT_GAS_BOMB,    20000, 0, PHASE_THREE);
                     break;
             }
         }
@@ -141,6 +135,5 @@ struct boss_alice : public BossAI
 void AddSC_boss_alice()
 {
     RegisterCreatureAI(boss_alice);
-master
 }
 

--- a/src/npc_alice_start.cpp
+++ b/src/npc_alice_start.cpp
@@ -1,14 +1,6 @@
-codex/modify-cmakelists.txt-for-new-scripts
 /*
  * Placeholder script for NPC Alice start
  */
-
-#include "ScriptMgr.h"
-
-void AddSC_npc_alice_start()
-{
-}
-
 
 #include "Creature.h"
 #include "InstanceScript.h"
@@ -18,67 +10,69 @@ void AddSC_npc_alice_start()
 #include "ScriptMgr.h"
 #include "ScriptedGossip.h"
 
-enum AliceStart {
-  NPC_ALICE = 91001,
-
-  ACTION_START_BOSS = GOSSIP_ACTION_INFO_DEF + 1,
-  ACTION_TELEPORT = GOSSIP_ACTION_INFO_DEF + 2,
-
-  GOSSIP_TEXT_ID = 91000
+enum AliceStart
+{
+    NPC_ALICE        = 91001,
+    ACTION_START_BOSS = GOSSIP_ACTION_INFO_DEF + 1,
+    ACTION_TELEPORT   = GOSSIP_ACTION_INFO_DEF + 2,
+    GOSSIP_TEXT_ID    = 91000
 };
 
 static Position const AliceSummonPos = {100.0f, 100.0f, 20.0f, 0.0f};
-static Position const BossRoomPos = {120.0f, 120.0f, 20.0f, 0.0f};
+static Position const BossRoomPos    = {120.0f, 120.0f, 20.0f, 0.0f};
 
-class npc_alice_start : public CreatureScript {
+class npc_alice_start : public CreatureScript
+{
 public:
-  npc_alice_start() : CreatureScript("npc_alice_start") {}
+    npc_alice_start() : CreatureScript("npc_alice_start") { }
 
-  bool OnGossipHello(Player *player, Creature *creature) override {
-    player->PrepareGossipMenu(creature);
-    player->ADD_GOSSIP_ITEM(GOSSIP_ICON_CHAT, "Bosskampf starten",
-                            GOSSIP_SENDER_MAIN, ACTION_START_BOSS);
-    player->ADD_GOSSIP_ITEM(GOSSIP_ICON_CHAT, "Teleport zur Bosskammer",
-                            GOSSIP_SENDER_MAIN, ACTION_TELEPORT);
-    player->SendGossipMenu(GOSSIP_TEXT_ID, creature->GetGUID());
-    return true;
-  }
-
-  bool OnGossipSelect(Player *player, Creature *creature, uint32 sender,
-                      uint32 action) override {
-    if (sender != GOSSIP_SENDER_MAIN)
-      return false;
-
-    player->PlayerTalkClass->ClearMenus();
-
-    switch (action) {
-    case ACTION_START_BOSS: {
-      if (InstanceScript *instance = creature->GetInstanceScript()) {
-        if (Creature *alice =
-                instance->SummonCreature(NPC_ALICE, AliceSummonPos))
-          instance->DoZoneInCombat(alice);
-      }
-      creature->DespawnOrUnsummon();
-      break;
-    }
-    case ACTION_TELEPORT: {
-      if (Map *map = creature->GetMap()) {
-        Map::PlayerList const &players = map->GetPlayers();
-        for (Map::PlayerList::const_iterator itr = players.begin();
-             itr != players.end(); ++itr)
-          if (Player *plr = itr->GetSource())
-            plr->TeleportTo(creature->GetMapId(), BossRoomPos.GetPositionX(),
-                            BossRoomPos.GetPositionY(),
-                            BossRoomPos.GetPositionZ(),
-                            BossRoomPos.GetOrientation());
-      }
-      break;
-    }
+    bool OnGossipHello(Player* player, Creature* creature) override
+    {
+        player->PrepareGossipMenu(creature);
+        player->ADD_GOSSIP_ITEM(GOSSIP_ICON_CHAT, "Bosskampf starten", GOSSIP_SENDER_MAIN, ACTION_START_BOSS);
+        player->ADD_GOSSIP_ITEM(GOSSIP_ICON_CHAT, "Teleport zur Bosskammer", GOSSIP_SENDER_MAIN, ACTION_TELEPORT);
+        player->SendGossipMenu(GOSSIP_TEXT_ID, creature->GetGUID());
+        return true;
     }
 
-    return true;
-  }
+    bool OnGossipSelect(Player* player, Creature* creature, uint32 sender, uint32 action) override
+    {
+        if (sender != GOSSIP_SENDER_MAIN)
+            return false;
+
+        player->PlayerTalkClass->ClearMenus();
+
+        switch (action)
+        {
+            case ACTION_START_BOSS:
+            {
+                if (InstanceScript* instance = creature->GetInstanceScript())
+                {
+                    if (Creature* alice = instance->SummonCreature(NPC_ALICE, AliceSummonPos))
+                        instance->DoZoneInCombat(alice);
+                }
+                creature->DespawnOrUnsummon();
+                break;
+            }
+            case ACTION_TELEPORT:
+            {
+                if (Map* map = creature->GetMap())
+                {
+                    Map::PlayerList const& players = map->GetPlayers();
+                    for (Map::PlayerList::const_iterator itr = players.begin(); itr != players.end(); ++itr)
+                        if (Player* plr = itr->GetSource())
+                            plr->TeleportTo(creature->GetMapId(), BossRoomPos.GetPositionX(), BossRoomPos.GetPositionY(), BossRoomPos.GetPositionZ(), BossRoomPos.GetOrientation());
+                }
+                break;
+            }
+        }
+
+        return true;
+    }
 };
 
-void AddSC_npc_alice_start() { new npc_alice_start(); }
-master
+void AddSC_npc_alice_start()
+{
+    new npc_alice_start();
+}
+


### PR DESCRIPTION
## Summary
- Remove stray codex and master tokens from scripts and SQL data
- Consolidate includes and fix loader wiring
- Rewrite boss Alice registration with proper CreatureAI

## Testing
- `g++ -c src/boss_alice.cpp` (fails: ScriptMgr.h: No such file or directory)
- `g++ -c src/npc_alice_start.cpp` (fails: Creature.h: No such file or directory)


------
https://chatgpt.com/codex/tasks/task_e_689cdea4bf908327b317930c727a136b