### PR TITLE
Refactor script loader and clean stray markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 # Bloody Raid Module
 
-codex/add-sql-files-for-game-world-features
-
-smihjq-codex/add-sql-files-for-game-world-features
-master
 This module adds the Smaragdsanktum raid with custom NPCs, instance data, waypoints, spell tweaks and loot tables.
 
 ## Importing the SQL files
@@ -25,10 +21,6 @@ mysql -u <user> -p world < data/sql/db-world/waypoints.sql
 mysql -u <user> -p world < data/sql/db-world/spells_override.sql
 mysql -u <user> -p world < data/sql/db-world/loot_tables.sql
 ```
-
-Replace `world` with the name of your world database.
-codex/add-sql-files-for-game-world-features
-
 
 This module adds a custom raid encounter to [AzerothCore](https://www.azerothcore.org).
 It targets the **master** branch of AzerothCore and does not require any core modifications.
@@ -72,6 +64,3 @@ When `MyModule.Enable` is set, a greeting will be sent to players on login. Addi
 
 ## License
 This project is released under the terms of the [GNU AGPL v3](LICENSE).
-
-master
-master

--- a/data/sql/db-world/npc_alice.sql
+++ b/data/sql/db-world/npc_alice.sql
@@ -1,6 +1,4 @@
-codex/add-sql-files-for-game-world-features
-
-codex/add-npc_alice_start.cpp-with-creaturescript
+-- SQL setup for the Alice encounter
 SET @NPC := 91000;
 SET @GOSSIP_MENU := 91000;
 SET @GOSSIP_TEXT := 91000;
@@ -13,7 +11,6 @@ INSERT INTO `npc_text` (`ID`, `text0_0`) VALUES (@GOSSIP_TEXT, 'Seid ihr bereit 
 
 UPDATE `creature_template` SET `gossip_menu_id`=@GOSSIP_MENU, `npcflag`=`npcflag`|1, `ScriptName`='npc_alice_start' WHERE `entry`=@NPC;
 
-master
 -- NPC and Boss templates for Smaragdsanktum
 SET @START_NPC := 90000;
 SET @BOSS := 90001;
@@ -29,7 +26,3 @@ DELETE FROM `creature_model_info` WHERE `modelid` IN (31000,31001);
 INSERT INTO `creature_model_info` (`modelid`,`bounding_radius`,`combat_reach`,`gender`) VALUES
 (31000,0.3519,1.5,1),
 (31001,1.5,4.0,2);
-codex/add-sql-files-for-game-world-features
-
-master
-master

--- a/src/MP_loader.cpp
+++ b/src/MP_loader.cpp
@@ -4,32 +4,24 @@
  * https://github.com/azerothcore/azerothcore-wotlk/blob/master/LICENSE-AGPL3
  */
 
-codex/modify-cmakelists.txt-for-new-scripts
 // Forward declare AddSC functions from script files
-
-// From SC
-master
 void AddSC_boss_alice();
 void AddSC_instance_smaragdsanktum();
 void AddSC_npc_alice_start();
 
-codex/modify-cmakelists.txt-for-new-scripts
 // Add all scripts
 void Addbloody_raid_modulScripts()
 {
     AddSC_boss_alice();
     AddSC_instance_smaragdsanktum();
     AddSC_npc_alice_start();
-
-void AddAliceScripts() {
-  AddSC_boss_alice();
-  AddSC_instance_smaragdsanktum();
-  AddSC_npc_alice_start();
-master
 }
 
 // Add all
 // cf. the naming convention
 // https://github.com/azerothcore/azerothcore-wotlk/blob/master/doc/changelog/master.md#how-to-upgrade
 // additionally replace all '-' in the module folder name with '_' here
-void Addmod_bloody_raid_modulScripts() { AddAliceScripts(); }
+void Addmod_bloody_raid_modulScripts()
+{
+    Addbloody_raid_modulScripts();
+}

--- a/src/boss_alice.cpp
+++ b/src/boss_alice.cpp
@@ -1,12 +1,6 @@
-codex/modify-cmakelists.txt-for-new-scripts
 /*
  * Placeholder script for boss Alice encounter
  */
-
-#include "ScriptMgr.h"
-
-void AddSC_boss_alice()
-{
 
 #include "ScriptMgr.h"
 #include "ScriptedCreature.h"
@@ -141,6 +135,4 @@ struct boss_alice : public BossAI
 void AddSC_boss_alice()
 {
     RegisterCreatureAI(boss_alice);
-master
 }
-

--- a/src/npc_alice_start.cpp
+++ b/src/npc_alice_start.cpp
@@ -1,14 +1,6 @@
-codex/modify-cmakelists.txt-for-new-scripts
 /*
  * Placeholder script for NPC Alice start
  */
-
-#include "ScriptMgr.h"
-
-void AddSC_npc_alice_start()
-{
-}
-
 
 #include "Creature.h"
 #include "InstanceScript.h"
@@ -18,67 +10,70 @@ void AddSC_npc_alice_start()
 #include "ScriptMgr.h"
 #include "ScriptedGossip.h"
 
-enum AliceStart {
-  NPC_ALICE = 91001,
+enum AliceStart
+{
+    NPC_ALICE = 91001,
 
-  ACTION_START_BOSS = GOSSIP_ACTION_INFO_DEF + 1,
-  ACTION_TELEPORT = GOSSIP_ACTION_INFO_DEF + 2,
+    ACTION_START_BOSS = GOSSIP_ACTION_INFO_DEF + 1,
+    ACTION_TELEPORT   = GOSSIP_ACTION_INFO_DEF + 2,
 
-  GOSSIP_TEXT_ID = 91000
+    GOSSIP_TEXT_ID = 91000
 };
 
 static Position const AliceSummonPos = {100.0f, 100.0f, 20.0f, 0.0f};
-static Position const BossRoomPos = {120.0f, 120.0f, 20.0f, 0.0f};
+static Position const BossRoomPos    = {120.0f, 120.0f, 20.0f, 0.0f};
 
-class npc_alice_start : public CreatureScript {
+class npc_alice_start : public CreatureScript
+{
 public:
-  npc_alice_start() : CreatureScript("npc_alice_start") {}
+    npc_alice_start() : CreatureScript("npc_alice_start") { }
 
-  bool OnGossipHello(Player *player, Creature *creature) override {
-    player->PrepareGossipMenu(creature);
-    player->ADD_GOSSIP_ITEM(GOSSIP_ICON_CHAT, "Bosskampf starten",
-                            GOSSIP_SENDER_MAIN, ACTION_START_BOSS);
-    player->ADD_GOSSIP_ITEM(GOSSIP_ICON_CHAT, "Teleport zur Bosskammer",
-                            GOSSIP_SENDER_MAIN, ACTION_TELEPORT);
-    player->SendGossipMenu(GOSSIP_TEXT_ID, creature->GetGUID());
-    return true;
-  }
-
-  bool OnGossipSelect(Player *player, Creature *creature, uint32 sender,
-                      uint32 action) override {
-    if (sender != GOSSIP_SENDER_MAIN)
-      return false;
-
-    player->PlayerTalkClass->ClearMenus();
-
-    switch (action) {
-    case ACTION_START_BOSS: {
-      if (InstanceScript *instance = creature->GetInstanceScript()) {
-        if (Creature *alice =
-                instance->SummonCreature(NPC_ALICE, AliceSummonPos))
-          instance->DoZoneInCombat(alice);
-      }
-      creature->DespawnOrUnsummon();
-      break;
-    }
-    case ACTION_TELEPORT: {
-      if (Map *map = creature->GetMap()) {
-        Map::PlayerList const &players = map->GetPlayers();
-        for (Map::PlayerList::const_iterator itr = players.begin();
-             itr != players.end(); ++itr)
-          if (Player *plr = itr->GetSource())
-            plr->TeleportTo(creature->GetMapId(), BossRoomPos.GetPositionX(),
-                            BossRoomPos.GetPositionY(),
-                            BossRoomPos.GetPositionZ(),
-                            BossRoomPos.GetOrientation());
-      }
-      break;
-    }
+    bool OnGossipHello(Player* player, Creature* creature) override
+    {
+        player->PrepareGossipMenu(creature);
+        player->ADD_GOSSIP_ITEM(GOSSIP_ICON_CHAT, "Bosskampf starten", GOSSIP_SENDER_MAIN, ACTION_START_BOSS);
+        player->ADD_GOSSIP_ITEM(GOSSIP_ICON_CHAT, "Teleport zur Bosskammer", GOSSIP_SENDER_MAIN, ACTION_TELEPORT);
+        player->SendGossipMenu(GOSSIP_TEXT_ID, creature->GetGUID());
+        return true;
     }
 
-    return true;
-  }
+    bool OnGossipSelect(Player* player, Creature* creature, uint32 sender, uint32 action) override
+    {
+        if (sender != GOSSIP_SENDER_MAIN)
+            return false;
+
+        player->PlayerTalkClass->ClearMenus();
+
+        switch (action)
+        {
+            case ACTION_START_BOSS:
+            {
+                if (InstanceScript* instance = creature->GetInstanceScript())
+                {
+                    if (Creature* alice = instance->SummonCreature(NPC_ALICE, AliceSummonPos))
+                        instance->DoZoneInCombat(alice);
+                }
+                creature->DespawnOrUnsummon();
+                break;
+            }
+            case ACTION_TELEPORT:
+            {
+                if (Map* map = creature->GetMap())
+                {
+                    Map::PlayerList const& players = map->GetPlayers();
+                    for (Map::PlayerList::const_iterator itr = players.begin(); itr != players.end(); ++itr)
+                        if (Player* plr = itr->GetSource())
+                            plr->TeleportTo(creature->GetMapId(), BossRoomPos.GetPositionX(), BossRoomPos.GetPositionY(), BossRoomPos.GetPositionZ(), BossRoomPos.GetOrientation());
+                }
+                break;
+            }
+        }
+
+        return true;
+    }
 };
 
-void AddSC_npc_alice_start() { new npc_alice_start(); }
-master
+void AddSC_npc_alice_start()
+{
+    new npc_alice_start();
+}


### PR DESCRIPTION
## Summary
- remove leftover codex/master markers across module
- consolidate script loader into `Addbloody_raid_modulScripts`
- fix script files to forward declare and register correctly

## Testing
- `cmake -S . -B build` *(fails: Unknown CMake command "AC_ADD_SCRIPT")*


------
https://chatgpt.com/codex/tasks/task_e_689cdea62aa48327b7f9db44facd8cd6